### PR TITLE
Fix teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Instant provides a [permissions layer](https://www.instantdb.com/docs/permission
   "invites": {
     "bind": [
       "isMember",
-      "auth.id in data.ref('team.memberships.userId')",
+      "auth.id in data.ref('teams.memberships.userId')",
       "isInvitee",
       "auth.email == data.userEmail"
     ],
@@ -126,7 +126,10 @@ Instant provides a [permissions layer](https://www.instantdb.com/docs/permission
     }
   },
   "drawings": {
-    "bind": ["isMember", "auth.id in data.ref('team.memberships.userId')"],
+    "bind": [
+      "isMember",
+      "auth.id in data.ref('teams.memberships.userId')"
+    ],
     "allow": {
       "view": "isMember",
       "create": "isMember",
@@ -137,9 +140,9 @@ Instant provides a [permissions layer](https://www.instantdb.com/docs/permission
   "memberships": {
     "bind": [
       "isMember",
-      "auth.id in data.ref('team.memberships.userId')",
+      "auth.id in data.ref('teams.memberships.userId')",
       "isInviteeOrCreator",
-      "size(data.ref('team.invites.id')) == 0 ? auth.id in data.ref('team.creatorId') : auth.email in data.ref('team.invites.userEmail')",
+      "size(data.ref('teams.invites.id')) == 0 ? auth.id in data.ref('teams.creatorId') : auth.email in data.ref('teams.invites.userEmail')",
       "isUser",
       "auth.id == data.userId"
     ],

--- a/src/mutators.ts
+++ b/src/mutators.ts
@@ -13,7 +13,7 @@ export async function createDrawingForTeam({
 
   const result = await db.transact([
     tx.drawings[drawingId].merge({ name: drawingName ?? "Untitled" }),
-    tx.drawings[drawingId].link({ team: teamId }),
+    tx.drawings[drawingId].link({ teams: teamId }),
     tx.teams[teamId].link({ drawings: drawingId }),
   ]);
 
@@ -35,7 +35,7 @@ export async function createTeamWithMember({
   const result = await db.transact([
     tx.teams[teamId].update({ name: teamName, creatorId: userId }),
     tx.memberships[membershipId].update({ teamId, userId, userEmail }),
-    tx.memberships[membershipId].link({ team: teamId }),
+    tx.memberships[membershipId].link({ teams: teamId }),
   ]);
 
   return {
@@ -60,7 +60,7 @@ export async function inviteMemberToTeam({
 
   const result = await db.transact([
     tx.invites[inviteId].update({ userEmail, teamId, teamName }),
-    tx.invites[inviteId].link({ team: teamId }),
+    tx.invites[inviteId].link({ teams: teamId }),
   ]);
 
   return {
@@ -82,7 +82,7 @@ export async function acceptInvite({
 
   const result = await db.transact([
     tx.memberships[membershipId].update({ teamId, userId, userEmail }),
-    tx.memberships[membershipId].link({ team: teamId }),
+    tx.memberships[membershipId].link({ teams: teamId }),
   ]);
 
   return {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -195,7 +195,7 @@ function Team({
     drawings: {
       $: {
         where: {
-          "team.id": team.id,
+          "teams.id": team.id,
         },
         limit: drawingsPerPage,
         offset: drawingsPerPage * (pageNumber - 1),
@@ -204,7 +204,7 @@ function Team({
     memberships: {
       $: {
         where: {
-          "team.id": team.id,
+          "teams.id": team.id,
         },
       },
     },
@@ -222,7 +222,7 @@ function Team({
     drawings: {
       $: {
         where: {
-          "team.id": team.id,
+          "teams.id": team.id,
         },
         limit: drawingsPerPage + 1,
         offset: drawingsPerPage * (pageNumber - 1),


### PR DESCRIPTION
@markyfyi Cesar couldn't get the tldraw example working locally and emailed us about it.

He mentioned an issue with permissions so I tried setting up the app from scratch. I noticed creating teams wouldn't show up and I realized the issue was due to having a custom attribute in explorer.

In the instldraw app you renamed `teams` to `team.` But anyone following the README wouldn't know this. Permissions would then fail and throw the error.

<img width="581" alt="image" src="https://github.com/user-attachments/assets/5073480f-8ccb-4e9d-8e9d-b1fa38fb4211">

I updated query, transact, and permissions to use `teams` instead and it all worked as expected

Alternatively, we could update the README to tell users to configure custom attributes for `memberships` and `drawings`. Feels like that's more steps for a user though so figured updating the code could be better and then we can just update the custom attribute on our end? What do you think?