### PR TITLE
[instldraw] upgrade to latest Instant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# env 
+.env

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ https://github.com/jsventures/instldraw/assets/1624703/bde87c77-10b5-4267-9c82-2
 
 ### ⚡ 1. Create a free account on [Instant](https://www.instantdb.com/)
 
-Head on over to the [Instant dashboard](https://www.instantdb.com/dash), grab your app's ID, and plop it into a `.env.development.local` file:
+Head on over to the [Instant dashboard](https://www.instantdb.com/dash), grab your app's ID, and plop it into a `.env` file:
 
 ```bash
 NEXT_PUBLIC_INSTANT_APP_ID=__YOUR_APP_ID__
@@ -53,13 +53,15 @@ Both pages load data from Instant with `db.useQuery` and write data using functi
 
 ### 📄 Notable Files
 
-- `instant.schema.ts`: Contains the schema for the app's data model.
-- `instant.perms.ts`: Contains the permissions for the app.
+- `src/instant.schema.ts`: Contains the schema for the app's data model.
+- `src/instant.perms.ts`: Contains the permissions for the app.
 - `src/pages/index.tsx`: The main dashboard: list and manage teams, teammates, and drawings.
 - `src/pages/drawings/[id].tsx`: The canvas! Uses `useInstantStore` and `useInstantPresence` to add multiplayer.
+- `src/lib/clientDB.tsx`: Exports our Instant database!
 - `src/lib/useInstantStore.tsx`: A collaborative backend for tldraw built on top of Instant's real-time database. Uses InstaML's [merge()](https://www.instantdb.com/docs/instaml#merge) for fine-grained updates to the drawing state.
 - `src/lib/useInstantPresence.tsx`: A React hook responsible for keeping tldraw's editor state in sync with [Instant's real-time presence API](https://www.instantdb.com/docs/presence-and-topics).
 - `src/mutators.ts`: All functions that update Instant's database live here. You can inspect and edit your database using the [Instant Explorer](https://www.instantdb.com/dash?s=main&t=explorer).
 
 ## Why Instant?
+
 Instant is a sync engine inspired by Firebase with support for relational data. To learn more, check out [this essay](https://www.instantdb.com/essays/next_firebase).

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@instantdb/react": "^0.14.3",
+    "@instantdb/react": "^0.17.27",
     "lodash": "^4.17.21",
     "next": "14.2.4",
     "react": "^18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@instantdb/react':
-    specifier: ^0.14.3
-    version: 0.14.3(react@18.3.1)
+    specifier: ^0.17.27
+    version: 0.17.27(react@18.3.1)
   lodash:
     specifier: ^4.17.21
     version: 4.17.21
@@ -92,20 +92,19 @@ packages:
     resolution: {integrity: sha512-dWO2pw8hhi+WrXq1YJy2yCuWoL20PddgGaqTgVe4cOS9Q6qklXCiA1tJEqX6BEwRNSCP84/afac9hd4MS+zEUA==}
     dev: false
 
-  /@instantdb/core@0.14.3:
-    resolution: {integrity: sha512-IWYTwjR9Vb1DdjNi4OljmTyaZkaw/EZFdwLD9PG3GPPDV8SyNIhMLc0s6jy+4k77Wql2JKKx3IsXvb4Vq7fqbg==}
+  /@instantdb/core@0.17.27:
+    resolution: {integrity: sha512-TuZMCDsxVEwRI8MGkz5Mzb6Dyo6C6xX5ifVWbNOUexY9CA9ZiarFhAd3k9q5ZDSqbq0aHye8zmeYiJgAkPmQjg==}
     dependencies:
       mutative: 1.0.10
-      object-hash: 3.0.0
       uuid: 9.0.1
     dev: false
 
-  /@instantdb/react@0.14.3(react@18.3.1):
-    resolution: {integrity: sha512-Iw6Tps7MdM/rSa1YPGthqkBD7ylkd1akxzOhd8WcBKNNtXcjm7e8bn0sEIPrgIncdzuKTAVSVisId2sdmp45TQ==}
+  /@instantdb/react@0.17.27(react@18.3.1):
+    resolution: {integrity: sha512-oUa8hn2coAIlUgeAvJ+vUMgcnLIyCpB10Uw8iQDL7NfdU/tzxk15OBCqfuB+434nMlEL6aQGHVyNHeATtmtXHg==}
     peerDependencies:
       react: '>=16'
     dependencies:
-      '@instantdb/core': 0.14.3
+      '@instantdb/core': 0.17.27
       react: 18.3.1
     dev: false
 
@@ -1970,6 +1969,7 @@ packages:
   /object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
+    dev: true
 
   /package-json-from-dist@1.0.0:
     resolution: {integrity: sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==}

--- a/src/__dev.tsx
+++ b/src/__dev.tsx
@@ -1,62 +1,16 @@
-import { tx } from "@instantdb/react";
-import { db, isBrowser, isDev } from "@/config";
+import { isBrowser, isDev } from "@/config";
+import clientDB from "./lib/clientDB";
 
 // auth dev utils
 
 async function getUser() {
-  return (await db._core._reactor.getCurrentUser())?.user;
-}
-
-async function authn() {
-  const email = prompt("Email 📧");
-  if (!email) {
-    alert("Please provide an email");
-    return;
-  }
-  await db.auth.sendMagicCode({ email });
-  const code = prompt("Check your email for the magic code 🪄");
-  if (!code) {
-    alert("Please try again and provide an code");
-    return;
-  }
-  try {
-    await db.auth.signInWithMagicCode({ email, code });
-    alert("Signed in 👍");
-  } catch (error) {
-    alert("Failed to sign in ❌");
-  }
-}
-
-// random stuff
-// @ts-ignore
-function quickTransact(op, ns, eid, v) {
-  return db.transact([
-    // @ts-ignore
-    tx[ns][eid][op](v),
-  ]);
-}
-
-function oneOffQuery(query: any) {
-  return new Promise((resolve, reject) => {
-    const unsub = db._core.subscribeQuery(query, (r) => {
-      if (r.error) {
-        reject(r.error);
-      } else {
-        resolve(r.data);
-      }
-
-      unsub();
-    });
-  });
+  return (await clientDB._core._reactor.getCurrentUser())?.user;
 }
 
 // dev-only!
 if (isBrowser && isDev) {
   const g = globalThis as any;
 
-  g.$db = db;
-  g.$auth = authn;
+  g.$db = clientDB;
   g.$u = getUser;
-  g.$q = oneOffQuery;
-  g.$tx = quickTransact;
 }

--- a/src/components/InstantAuth.tsx
+++ b/src/components/InstantAuth.tsx
@@ -3,11 +3,6 @@ import clientDB from "@/lib/clientDB";
 
 // Instant auth copypasta https://www.instantdb.com/docs/auth#magic-codes
 
-import { User } from "@instantdb/react";
-
-// ID for app: instantgram
-const APP_ID = "5a7a526e-954a-47c1-ab85-e57cdf1ea773";
-
 export function InstantAuth() {
   const [sentEmail, setSentEmail] = useState("");
 

--- a/src/components/InstantAuth.tsx
+++ b/src/components/InstantAuth.tsx
@@ -1,115 +1,109 @@
-import { useState } from "react";
-import { db } from "@/config";
+import React, { useState } from "react";
+import clientDB from "@/lib/clientDB";
 
 // Instant auth copypasta https://www.instantdb.com/docs/auth#magic-codes
 
+import { User } from "@instantdb/react";
+
+// ID for app: instantgram
+const APP_ID = "5a7a526e-954a-47c1-ab85-e57cdf1ea773";
+
 export function InstantAuth() {
   const [sentEmail, setSentEmail] = useState("");
+
   return (
-    <div style={authStyles.container}>
-      {!sentEmail ? (
-        <Email setSentEmail={setSentEmail} />
-      ) : (
-        <MagicCode sentEmail={sentEmail} />
-      )}
+    <div className="flex justify-center items-center min-h-screen">
+      <div className="max-w-sm">
+        {!sentEmail ? (
+          <EmailStep onSendEmail={setSentEmail} />
+        ) : (
+          <CodeStep sentEmail={sentEmail} />
+        )}
+      </div>
     </div>
   );
 }
 
-function Email({ setSentEmail }: { setSentEmail: (email: string) => void }) {
-  const [email, setEmail] = useState("");
-
+function EmailStep({ onSendEmail }: { onSendEmail: (email: string) => void }) {
+  const inputRef = React.useRef<HTMLInputElement>(null);
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!email) return;
-    setSentEmail(email);
-    db.auth.sendMagicCode({ email }).catch((err) => {
-      alert("Uh oh: " + err.body?.message);
-      setSentEmail("");
+    const inputEl = inputRef.current!;
+    const email = inputEl.value;
+    onSendEmail(email);
+    clientDB.auth.sendMagicCode({ email }).catch((err) => {
+      alert("Uh oh :" + err.body?.message);
+      onSendEmail("");
     });
   };
-
   return (
-    <form onSubmit={handleSubmit} style={authStyles.form}>
-      <h2 style={{ color: "#333", marginBottom: "20px" }}>Let's log you in!</h2>
-      <div>
-        <input
-          style={authStyles.input}
-          placeholder="Enter your email"
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-        />
-      </div>
-      <div>
-        <button type="submit" style={authStyles.button}>
-          Send Code
-        </button>
-      </div>
-    </form>
-  );
-}
-
-function MagicCode({ sentEmail }: { sentEmail: string }) {
-  const [code, setCode] = useState("");
-
-  function signInWithMagicCode(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-    db.auth.signInWithMagicCode({ email: sentEmail, code }).catch((err) => {
-      alert("Uh oh :" + err.body?.message);
-      setCode("");
-    });
-  }
-
-  return (
-    <form onSubmit={signInWithMagicCode} style={authStyles.form}>
-      <h2 style={{ color: "#333", marginBottom: "20px" }}>
-        Okay, we sent you an email! What was the code?
-      </h2>
-      <div>
-        <input
-          style={authStyles.input}
-          type="text"
-          placeholder="123456..."
-          value={code}
-          onChange={(e) => setCode(e.target.value)}
-        />
-      </div>
-      <button type="submit" style={authStyles.button}>
-        Verify
+    <form
+      key="email"
+      onSubmit={handleSubmit}
+      className="flex flex-col space-y-4"
+    >
+      <h2 className="text-xl font-bold">Let's log you in</h2>
+      <p className="text-gray-700">
+        Enter your email, and we'll send you a verification code. We'll create
+        an account for you too if you don't already have one.
+      </p>
+      <input
+        ref={inputRef}
+        type="email"
+        className="border border-gray-300 px-3 py-1  w-full"
+        placeholder="Enter your email"
+        required
+        autoFocus
+      />
+      <button
+        type="submit"
+        className="px-3 py-1 bg-blue-600 text-white font-bold hover:bg-blue-700 w-full"
+      >
+        Send Code
       </button>
     </form>
   );
 }
 
-const authStyles: Record<string, React.CSSProperties> = {
-  container: {
-    display: "flex",
-    justifyContent: "center",
-    alignItems: "center",
-    height: "100vh",
-  },
-  form: {
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "center",
-    justifyContent: "center",
-    height: "100vh",
-    fontFamily: "Arial, sans-serif",
-  },
-  input: {
-    padding: "10px",
-    marginBottom: "15px",
-    border: "1px solid #ddd",
-    borderRadius: "5px",
-    width: "300px",
-  },
-  button: {
-    padding: "10px 20px",
-    backgroundColor: "#007bff",
-    color: "white",
-    border: "none",
-    borderRadius: "5px",
-    cursor: "pointer",
-  },
-};
+function CodeStep({ sentEmail }: { sentEmail: string }) {
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const inputEl = inputRef.current!;
+    const code = inputEl.value;
+    clientDB.auth
+      .signInWithMagicCode({ email: sentEmail, code })
+      .catch((err) => {
+        inputEl.value = "";
+        alert("Uh oh :" + err.body?.message);
+      });
+  };
+
+  return (
+    <form
+      key="code"
+      onSubmit={handleSubmit}
+      className="flex flex-col space-y-4"
+    >
+      <h2 className="text-xl font-bold">Enter your code</h2>
+      <p className="text-gray-700">
+        We sent an email to <strong>{sentEmail}</strong>. Check your email, and
+        paste the code you see.
+      </p>
+      <input
+        ref={inputRef}
+        type="text"
+        className="border border-gray-300 px-3 py-1  w-full"
+        placeholder="123456..."
+        required
+        autoFocus
+      />
+      <button
+        type="submit"
+        className="px-3 py-1 bg-blue-600 text-white font-bold hover:bg-blue-700 w-full"
+      >
+        Verify Code
+      </button>
+    </form>
+  );
+}

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -1,24 +1,9 @@
-import schema from "../instant.schema"
-import { init_experimental } from "@instantdb/react";
-import { TLInstancePresence, uniqueId } from "tldraw";
-
-const appId = process.env.NEXT_PUBLIC_INSTANT_APP_ID!;
+import { uniqueId } from "tldraw";
 
 export const isDev = process.env.NODE_ENV === "development";
 export const isBrowser = typeof window != "undefined";
 
 export const localSourceId = uniqueId();
-
-type RoomSchema = {
-  drawings: {
-    presence: { tldraw: TLInstancePresence };
-  };
-}
-
-export const db = init_experimental({
-  appId,
-  schema: schema.withRoomSchema<RoomSchema>()
-})
 
 export const colorNames = [
   "magenta",

--- a/src/instant.perms.ts
+++ b/src/instant.perms.ts
@@ -1,4 +1,6 @@
-export default {
+import { InstantRules } from "@instantdb/react";
+
+const rules = {
   teams: {
     bind: [
       "isCreator",
@@ -52,4 +54,6 @@ export default {
       update: "false",
     },
   },
-};
+} satisfies InstantRules;
+
+export default rules;

--- a/src/instant.schema.ts
+++ b/src/instant.schema.ts
@@ -1,9 +1,8 @@
-import "dotenv/config";
-
 import { i } from "@instantdb/react";
+import { TLInstancePresence } from "tldraw";
 
-const graph = i.graph(
-  {
+const schema = i.schema({
+  entities: {
     drawings: i.entity({
       name: i.string(),
       state: i.json(),
@@ -23,7 +22,7 @@ const graph = i.graph(
       name: i.string(),
     }),
   },
-  {
+  links: {
     drawingsTeams: {
       forward: {
         on: "drawings",
@@ -60,7 +59,14 @@ const graph = i.graph(
         label: "memberships",
       },
     },
-  }
-);
+  },
+  rooms: {
+    drawings: {
+      presence: i.entity({
+        tldraw: i.json<TLInstancePresence>(),
+      }),
+    },
+  },
+});
 
-export default graph;
+export default schema;

--- a/src/lib/clientDB.tsx
+++ b/src/lib/clientDB.tsx
@@ -1,0 +1,11 @@
+import schema from "@/instant.schema";
+import { init } from "@instantdb/react";
+
+const appId = process.env.NEXT_PUBLIC_INSTANT_APP_ID!;
+
+const clientDB = init({
+  appId,
+  schema,
+});
+
+export default clientDB;

--- a/src/lib/useInstantPresence.tsx
+++ b/src/lib/useInstantPresence.tsx
@@ -1,4 +1,5 @@
-import { db } from "@/config";
+import clientDB from "@/lib/clientDB";
+
 import { useEffect, useRef } from "react";
 import {
   atom,
@@ -18,7 +19,7 @@ export function useInstantPresence({
   drawingId: string;
   user: { id: string; color: string; name: string };
 }) {
-  const room = db.room("drawings", drawingId);
+  const room = clientDB.room("drawings", drawingId);
   const presence = room.usePresence();
   const prevPeersRef = useRef<Record<string, { tldraw: TLInstancePresence }>>(
     {}

--- a/src/lib/useInstantPresence.tsx
+++ b/src/lib/useInstantPresence.tsx
@@ -20,7 +20,7 @@ export function useInstantPresence({
   user: { id: string; color: string; name: string };
 }) {
   const room = clientDB.room("drawings", drawingId);
-  const presence = room.usePresence();
+  const presence = clientDB.rooms.usePresence(room);
   const prevPeersRef = useRef<Record<string, { tldraw: TLInstancePresence }>>(
     {}
   );

--- a/src/lib/useInstantStore.tsx
+++ b/src/lib/useInstantStore.tsx
@@ -14,7 +14,7 @@ import {
 } from "tldraw";
 
 import type { DrawingState } from "@/types";
-import { db } from "@/config";
+import clientDB from "./clientDB";
 import { updateDrawingState } from "@/mutators";
 
 export function useInstantStore({
@@ -65,7 +65,7 @@ export function useInstantStore({
       shapeUtils: [...defaultShapeUtils],
     });
 
-    db._core.subscribeQuery(
+    clientDB._core.subscribeQuery(
       {
         drawings: {
           $: {

--- a/src/mutators.ts
+++ b/src/mutators.ts
@@ -1,6 +1,6 @@
 import type { DrawingState } from "@/types";
-import { id, tx } from "@instantdb/react";
-import { db } from "@/config";
+import { id } from "@instantdb/react";
+import clientDB from "@/lib/clientDB";
 
 export async function createDrawingForTeam({
   teamId,
@@ -11,10 +11,10 @@ export async function createDrawingForTeam({
 }) {
   const drawingId = id();
 
-  const result = await db.transact([
-    tx.drawings[drawingId].merge({ name: drawingName ?? "Untitled" }),
-    tx.drawings[drawingId].link({ teams: teamId }),
-    tx.teams[teamId].link({ drawings: drawingId }),
+  const result = await clientDB.transact([
+    clientDB.tx.drawings[drawingId].merge({ name: drawingName ?? "Untitled" }),
+    clientDB.tx.drawings[drawingId].link({ teams: teamId }),
+    clientDB.tx.teams[teamId].link({ drawings: drawingId }),
   ]);
 
   return { result, vars: { drawingId } };
@@ -32,10 +32,10 @@ export async function createTeamWithMember({
   const teamId = id();
   const membershipId = id();
 
-  const result = await db.transact([
-    tx.teams[teamId].update({ name: teamName, creatorId: userId }),
-    tx.memberships[membershipId].update({ teamId, userId, userEmail }),
-    tx.memberships[membershipId].link({ teams: teamId }),
+  const result = await clientDB.transact([
+    clientDB.tx.teams[teamId].update({ name: teamName, creatorId: userId }),
+    clientDB.tx.memberships[membershipId].update({ teamId, userId, userEmail }),
+    clientDB.tx.memberships[membershipId].link({ teams: teamId }),
   ]);
 
   return {
@@ -58,9 +58,9 @@ export async function inviteMemberToTeam({
 }) {
   const inviteId = id();
 
-  const result = await db.transact([
-    tx.invites[inviteId].update({ userEmail, teamId, teamName }),
-    tx.invites[inviteId].link({ teams: teamId }),
+  const result = await clientDB.transact([
+    clientDB.tx.invites[inviteId].update({ userEmail, teamId, teamName }),
+    clientDB.tx.invites[inviteId].link({ teams: teamId }),
   ]);
 
   return {
@@ -80,9 +80,9 @@ export async function acceptInvite({
 }) {
   const membershipId = id();
 
-  const result = await db.transact([
-    tx.memberships[membershipId].update({ teamId, userId, userEmail }),
-    tx.memberships[membershipId].link({ teams: teamId }),
+  const result = await clientDB.transact([
+    clientDB.tx.memberships[membershipId].update({ teamId, userId, userEmail }),
+    clientDB.tx.memberships[membershipId].link({ teams: teamId }),
   ]);
 
   return {
@@ -90,8 +90,8 @@ export async function acceptInvite({
   };
 }
 export async function declineInvite({ inviteId }: { inviteId: string }) {
-  const result = await db.transact([
-    tx.invites[inviteId].merge({ status: "declined" }),
+  const result = await clientDB.transact([
+    clientDB.tx.invites[inviteId].merge({ status: "declined" }),
   ]);
 
   return {
@@ -106,7 +106,7 @@ export function updateDrawingState({
   drawingId: string;
   state: DrawingState;
 }) {
-  return db.transact(tx.drawings[drawingId].merge({ state }));
+  return clientDB.transact(clientDB.tx.drawings[drawingId].merge({ state }));
 }
 
 export function updateDrawingName({
@@ -116,9 +116,9 @@ export function updateDrawingName({
   drawingId: string;
   name: string;
 }) {
-  return db.transact(tx.drawings[drawingId].merge({ name }));
+  return clientDB.transact(clientDB.tx.drawings[drawingId].merge({ name }));
 }
 
 export function deleteDrawing({ drawingId }: { drawingId: string }) {
-  return db.transact(tx.drawings[drawingId].delete());
+  return clientDB.transact(clientDB.tx.drawings[drawingId].delete());
 }

--- a/src/pages/drawings/[id].tsx
+++ b/src/pages/drawings/[id].tsx
@@ -6,10 +6,11 @@ import { Tldraw, useEditor } from "tldraw";
 import { updateDrawingName } from "@/mutators";
 import { useInstantStore } from "@/lib/useInstantStore";
 import { useInstantPresence } from "@/lib/useInstantPresence";
-import { db, colorNames, localSourceId } from "@/config";
+import { colorNames, localSourceId } from "@/config";
+import clientDB from "@/lib/clientDB";
 
 export default function Page() {
-  const auth = db.useAuth();
+  const auth = clientDB.useAuth();
 
   const router = useRouter();
   const drawingId = router.query.id as string;
@@ -39,7 +40,7 @@ function InstantTldraw({ drawingId }: { drawingId: string }) {
   const [displayName, setDisplayName] = useState<string>("");
   const [color, setColor] = useState<string>("blue");
 
-  const { data, isLoading: isDrawingLoading } = db.useQuery({
+  const { data, isLoading: isDrawingLoading } = clientDB.useQuery({
     drawings: {
       $: {
         where: {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { User } from "@instantdb/react";
 import { useRouter } from "next/router";
-import { db } from "@/config";
+import clientDB from "@/lib/clientDB";
 import { InstantAuth } from "@/components/InstantAuth";
 import { useDialog, PromptDialog } from "@/components/UI";
 
@@ -20,7 +20,7 @@ import "@/__dev";
 export const drawingsPerPage = 5;
 
 export default function Page() {
-  const auth = db.useAuth();
+  const auth = clientDB.useAuth();
 
   return (
     <div className="mx-auto max-w-md flex flex-col py-4 px-2 gap-3">
@@ -43,7 +43,7 @@ export default function Page() {
 function Index({ user }: { user: User }) {
   const teamDialog = useDialog();
   const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null);
-  const result = db.useQuery({
+  const result = clientDB.useQuery({
     teams: {
       $: {
         where: {
@@ -56,7 +56,7 @@ function Index({ user }: { user: User }) {
         where: {
           userEmail: user.email,
         },
-      }
+      },
     },
   });
 
@@ -190,7 +190,7 @@ function Team({
   const inviteMemberDialog = useDialog();
   const newDrawingDialog = useDialog();
 
-  const { isLoading, error, data } = db.useQuery({
+  const { isLoading, error, data } = clientDB.useQuery({
     drawings: {
       $: {
         where: {
@@ -217,7 +217,7 @@ function Team({
   // by fetching one more item than the page size
   // if there is a next page, we will enable a "next" button
   // in the future, useQuery should give us a way to check if there is a next page
-  const _pageLookaheadQuery = db.useQuery({
+  const _pageLookaheadQuery = clientDB.useQuery({
     drawings: {
       $: {
         where: {


### PR DESCRIPTION
1. Used `i.schema` instead of `i.graph`
2. Used `init` instead of `init_experimental`
3. Moved instant.schema.ts and instant.perms.ts in `src/`
4. Used the latest auth example from instantdb.com/docs 

Note: I am going to go on a slight side-quest, to see if we can upgrade the schema. Right now we have things like `userId` as attributes -- we likely want them as links. I'll play around with that in a separate PR.

@nezaj @dwwoelfel @tonsky